### PR TITLE
Add Python binding and test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,3 +6,10 @@ target_include_directories(shm PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+
+find_package(Python3 COMPONENTS Development REQUIRED)
+add_library(shm_py MODULE
+    python_module.cpp
+)
+set_target_properties(shm_py PROPERTIES PREFIX "")
+target_link_libraries(shm_py PRIVATE shm Python3::Python)

--- a/src/python_module.cpp
+++ b/src/python_module.cpp
@@ -1,0 +1,27 @@
+#include <Python.h>
+#include "shm/add.h"
+
+static PyObject* py_add(PyObject*, PyObject* args) {
+    int a, b;
+    if (!PyArg_ParseTuple(args, "ii", &a, &b))
+        return nullptr;
+    int result = add(a, b);
+    return PyLong_FromLong(result);
+}
+
+static PyMethodDef ShmMethods[] = {
+    {"add", py_add, METH_VARARGS, "Add two integers"},
+    {nullptr, nullptr, 0, nullptr}
+};
+
+static struct PyModuleDef shmModule = {
+    PyModuleDef_HEAD_INIT,
+    "shm_py",
+    "Python bindings for shm",
+    -1,
+    ShmMethods
+};
+
+PyMODINIT_FUNC PyInit_shm_py(void) {
+    return PyModule_Create(&shmModule);
+}

--- a/tests/test_python_add.py
+++ b/tests/test_python_add.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+# Add build directory to sys.path to import the compiled module
+build_dir = Path(__file__).resolve().parents[1] / "build" / "src"
+sys.path.insert(0, str(build_dir))
+
+import shm_py
+
+def test_add_from_python():
+    assert shm_py.add(2, 3) == 5


### PR DESCRIPTION
## Summary
- expose C++ `add` function to Python using the CPython API
- compile the Python module via CMake
- add a pytest that imports the compiled extension and checks `add`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c9cbd449883239ecab9a286e645e3