### PR TITLE
Fix Python test compatibility

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,3 +8,6 @@ add_test(
     NAME python_add_test
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/test_python_add.py
 )
+set_tests_properties(python_add_test PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/src"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,10 @@
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 add_executable(test_add test_add.cpp)
 target_link_libraries(test_add PRIVATE shm)
 add_test(NAME add_test COMMAND test_add)
+
+add_test(
+    NAME python_add_test
+    COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/test_python_add.py
+)

--- a/tests/test_python_add.py
+++ b/tests/test_python_add.py
@@ -1,12 +1,14 @@
 import sys
 import os
 
-# Add build directory to sys.path to import the compiled module
-build_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-    "build",
-    "src",
-)
+# PYTHONPATH is set by CTest to point to the built module
+build_dir = os.environ.get("PYTHONPATH")
+if not build_dir:
+    build_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        "build",
+        "src",
+    )
 sys.path.insert(0, build_dir)
 
 import shm_py

--- a/tests/test_python_add.py
+++ b/tests/test_python_add.py
@@ -1,9 +1,13 @@
 import sys
-from pathlib import Path
+import os
 
 # Add build directory to sys.path to import the compiled module
-build_dir = Path(__file__).resolve().parents[1] / "build" / "src"
-sys.path.insert(0, str(build_dir))
+build_dir = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "build",
+    "src",
+)
+sys.path.insert(0, build_dir)
 
 import shm_py
 


### PR DESCRIPTION
## Summary
- avoid using `pathlib` in Python test to support older Python versions
- run Python tests via CTest

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd build && ctest -V`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c9f84f2e883238b4c460ff8eabb1f