### PR TITLE
Add memory mapped file utility

### DIFF
--- a/include/shm/mapped_file.h
+++ b/include/shm/mapped_file.h
@@ -1,0 +1,59 @@
+#ifndef SHM_MAPPED_FILE_H
+#define SHM_MAPPED_FILE_H
+
+#include <cstddef>
+#include <string>
+
+namespace shm {
+
+class MappedFile {
+public:
+    enum class GrowthStrategy {
+        Fixed,
+        Double
+    };
+
+    MappedFile();
+    ~MappedFile();
+
+    // Create a new file and map it. Existing file will be truncated.
+    bool create(const std::string& path, std::size_t size,
+                GrowthStrategy growth = GrowthStrategy::Fixed);
+
+    // Open an existing file and map it. If size is non-zero and the file is
+    // smaller, it will be extended.
+    bool open(const std::string& path, std::size_t size = 0,
+              GrowthStrategy growth = GrowthStrategy::Fixed);
+
+    // Unmap and close the file.
+    void close();
+
+    // Pointer to mapped data.
+    void* data();
+    const void* data() const;
+
+    // Size of the mapped region.
+    std::size_t size() const;
+
+    // Ensure capacity at least new_size using the growth strategy.
+    bool ensure_size(std::size_t new_size);
+
+private:
+    GrowthStrategy growth_;
+#ifdef _WIN32
+    void* file_ = nullptr; // HANDLE
+    void* mapping_ = nullptr; // HANDLE
+#else
+    int fd_ = -1;
+#endif
+    void* data_ = nullptr;
+    std::size_t size_ = 0;
+
+    bool map_file(std::size_t size);
+    void unmap_file();
+    bool resize_file(std::size_t new_size);
+};
+
+} // namespace shm
+
+#endif // SHM_MAPPED_FILE_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(shm STATIC
     add.cpp
+    mapped_file.cpp
 )
 
 target_include_directories(shm PUBLIC

--- a/src/mapped_file.cpp
+++ b/src/mapped_file.cpp
@@ -1,0 +1,159 @@
+#include "shm/mapped_file.h"
+
+#include <algorithm>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+#include <cstring>
+
+namespace shm {
+
+MappedFile::MappedFile() = default;
+
+MappedFile::~MappedFile() { close(); }
+
+bool MappedFile::create(const std::string& path, std::size_t size,
+                        GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+#ifdef _WIN32
+    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE) return false;
+    mapping_ = nullptr;
+    size_ = size;
+    if (!resize_file(size_)) return false;
+    return true;
+#else
+    fd_ = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (fd_ < 0) return false;
+    size_ = size;
+    if (!resize_file(size_)) return false;
+    return true;
+#endif
+}
+
+bool MappedFile::open(const std::string& path, std::size_t size,
+                      GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+#ifdef _WIN32
+    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE) return false;
+    mapping_ = nullptr;
+    LARGE_INTEGER fileSize;
+    if (!GetFileSizeEx(reinterpret_cast<HANDLE>(file_), &fileSize)) return false;
+    size_ = static_cast<std::size_t>(fileSize.QuadPart);
+    if (size > size_) {
+        if (!resize_file(size)) return false;
+    } else {
+        if (!map_file(size_)) return false;
+    }
+    return true;
+#else
+    fd_ = ::open(path.c_str(), O_RDWR);
+    if (fd_ < 0) return false;
+    struct stat st;
+    if (fstat(fd_, &st) != 0) return false;
+    size_ = static_cast<std::size_t>(st.st_size);
+    if (size > size_) {
+        if (!resize_file(size)) return false;
+    } else {
+        if (!map_file(size_)) return false;
+    }
+    return true;
+#endif
+}
+
+void MappedFile::close() {
+    if (data_) {
+        unmap_file();
+    }
+#ifdef _WIN32
+    if (mapping_) {
+        CloseHandle(reinterpret_cast<HANDLE>(mapping_));
+        mapping_ = nullptr;
+    }
+    if (file_ && file_ != INVALID_HANDLE_VALUE) {
+        CloseHandle(reinterpret_cast<HANDLE>(file_));
+        file_ = nullptr;
+    }
+#else
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
+#endif
+    size_ = 0;
+}
+
+void* MappedFile::data() { return data_; }
+const void* MappedFile::data() const { return data_; }
+std::size_t MappedFile::size() const { return size_; }
+
+bool MappedFile::ensure_size(std::size_t new_size) {
+    if (new_size <= size_) return true;
+    std::size_t target = new_size;
+    if (growth_ == GrowthStrategy::Double) {
+        target = std::max(new_size, size_ * 2);
+    }
+    return resize_file(target);
+}
+
+bool MappedFile::map_file(std::size_t map_size) {
+#ifdef _WIN32
+    mapping_ = CreateFileMappingA(reinterpret_cast<HANDLE>(file_), nullptr,
+                                  PAGE_READWRITE, 0, static_cast<DWORD>(map_size),
+                                  nullptr);
+    if (!mapping_) return false;
+    data_ = MapViewOfFile(reinterpret_cast<HANDLE>(mapping_), FILE_MAP_ALL_ACCESS,
+                          0, 0, map_size);
+    if (!data_) return false;
+#else
+    data_ = ::mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+    if (data_ == MAP_FAILED) {
+        data_ = nullptr;
+        return false;
+    }
+#endif
+    size_ = map_size;
+    return true;
+}
+
+void MappedFile::unmap_file() {
+#ifdef _WIN32
+    if (data_) {
+        UnmapViewOfFile(data_);
+        data_ = nullptr;
+    }
+#else
+    if (data_) {
+        ::munmap(data_, size_);
+        data_ = nullptr;
+    }
+#endif
+}
+
+bool MappedFile::resize_file(std::size_t new_size) {
+    unmap_file();
+#ifdef _WIN32
+    LARGE_INTEGER li;
+    li.QuadPart = static_cast<LONGLONG>(new_size);
+    if (SetFilePointerEx(reinterpret_cast<HANDLE>(file_), li, nullptr, FILE_BEGIN) == 0)
+        return false;
+    if (!SetEndOfFile(reinterpret_cast<HANDLE>(file_))) return false;
+    return map_file(new_size);
+#else
+    if (ftruncate(fd_, new_size) != 0) return false;
+    return map_file(new_size);
+#endif
+}
+
+} // namespace shm
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,10 @@ add_executable(test_add test_add.cpp)
 target_link_libraries(test_add PRIVATE shm)
 add_test(NAME add_test COMMAND test_add)
 
+add_executable(test_mapped_file test_mapped_file.cpp)
+target_link_libraries(test_mapped_file PRIVATE shm)
+add_test(NAME mapped_file_test COMMAND test_mapped_file)
+
 add_test(
     NAME python_add_test
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/test_python_add.py

--- a/tests/test_mapped_file.cpp
+++ b/tests/test_mapped_file.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+#include <fstream>
+#include "shm/mapped_file.h"
+
+int main() {
+    shm::MappedFile mf;
+    const char* path = "test_mmap.bin";
+    assert(mf.create(path, 4096));
+    char* ptr = static_cast<char*>(mf.data());
+    ptr[0] = 'A';
+    mf.close();
+
+    std::ifstream in(path, std::ios::binary);
+    char c = 0;
+    in.read(&c, 1);
+    assert(c == 'A');
+    in.close();
+    std::remove(path);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement cross-platform `MappedFile` for memory mapped IO
- build `MappedFile` into `shm` library
- test mapping logic in new unit test

## Testing
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685de9fa47d48323981a3d9ac5e68c42