### PR TITLE
Implement strategy pattern for mapped file

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       # 1. Check out the code

--- a/include/shm/impl/mapped_file_posix.h
+++ b/include/shm/impl/mapped_file_posix.h
@@ -1,0 +1,43 @@
+#ifndef SHM_MAPPED_FILE_POSIX_H
+#define SHM_MAPPED_FILE_POSIX_H
+
+#include "shm/impl/mapped_file_strategy.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <algorithm>
+#include <cstring>
+
+namespace shm {
+
+class PosixMappedFile : public MappedFileStrategy {
+public:
+    PosixMappedFile();
+    ~PosixMappedFile() override;
+
+    bool create(const std::string& path, std::size_t size,
+                GrowthStrategy growth) override;
+    bool open(const std::string& path, std::size_t size,
+              GrowthStrategy growth) override;
+    void close() override;
+    void* data() override;
+    const void* data() const override;
+    std::size_t size() const override;
+    bool ensure_size(std::size_t new_size) override;
+
+private:
+    GrowthStrategy growth_ = GrowthStrategy::Fixed;
+    int fd_ = -1;
+    void* data_ = nullptr;
+    std::size_t size_ = 0;
+
+    bool map_file(std::size_t size);
+    void unmap_file();
+    bool resize_file(std::size_t new_size);
+};
+
+} // namespace shm
+
+#endif // SHM_MAPPED_FILE_POSIX_H

--- a/include/shm/impl/mapped_file_selector.h
+++ b/include/shm/impl/mapped_file_selector.h
@@ -1,0 +1,16 @@
+#ifndef SHM_MAPPED_FILE_SELECTOR_H
+#define SHM_MAPPED_FILE_SELECTOR_H
+
+#ifdef _WIN32
+#include "shm/impl/mapped_file_windows.h"
+namespace shm {
+using DefaultMappedFileImpl = WindowsMappedFile;
+}
+#else
+#include "shm/impl/mapped_file_posix.h"
+namespace shm {
+using DefaultMappedFileImpl = PosixMappedFile;
+}
+#endif
+
+#endif // SHM_MAPPED_FILE_SELECTOR_H

--- a/include/shm/impl/mapped_file_strategy.h
+++ b/include/shm/impl/mapped_file_strategy.h
@@ -1,0 +1,30 @@
+#ifndef SHM_MAPPED_FILE_STRATEGY_H
+#define SHM_MAPPED_FILE_STRATEGY_H
+
+#include <cstddef>
+#include <string>
+
+namespace shm {
+
+enum class GrowthStrategy {
+    Fixed,
+    Double
+};
+
+class MappedFileStrategy {
+public:
+    virtual ~MappedFileStrategy() = default;
+    virtual bool create(const std::string& path, std::size_t size,
+                        GrowthStrategy growth) = 0;
+    virtual bool open(const std::string& path, std::size_t size,
+                      GrowthStrategy growth) = 0;
+    virtual void close() = 0;
+    virtual void* data() = 0;
+    virtual const void* data() const = 0;
+    virtual std::size_t size() const = 0;
+    virtual bool ensure_size(std::size_t new_size) = 0;
+};
+
+} // namespace shm
+
+#endif // SHM_MAPPED_FILE_STRATEGY_H

--- a/include/shm/impl/mapped_file_windows.h
+++ b/include/shm/impl/mapped_file_windows.h
@@ -1,0 +1,44 @@
+#ifndef SHM_MAPPED_FILE_WINDOWS_H
+#define SHM_MAPPED_FILE_WINDOWS_H
+
+#include "shm/impl/mapped_file_strategy.h"
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <algorithm>
+#include <cstring>
+
+namespace shm {
+
+class WindowsMappedFile : public MappedFileStrategy {
+public:
+    WindowsMappedFile();
+    ~WindowsMappedFile() override;
+
+    bool create(const std::string& path, std::size_t size,
+                GrowthStrategy growth) override;
+    bool open(const std::string& path, std::size_t size,
+              GrowthStrategy growth) override;
+    void close() override;
+    void* data() override;
+    const void* data() const override;
+    std::size_t size() const override;
+    bool ensure_size(std::size_t new_size) override;
+
+private:
+    GrowthStrategy growth_ = GrowthStrategy::Fixed;
+    void* file_ = nullptr;   // HANDLE
+    void* mapping_ = nullptr; // HANDLE
+    void* data_ = nullptr;
+    std::size_t size_ = 0;
+
+    bool map_file(std::size_t size);
+    void unmap_file();
+    bool resize_file(std::size_t new_size);
+};
+
+} // namespace shm
+
+#endif // SHM_MAPPED_FILE_WINDOWS_H

--- a/include/shm/mapped_file.h
+++ b/include/shm/mapped_file.h
@@ -2,56 +2,31 @@
 #define SHM_MAPPED_FILE_H
 
 #include <cstddef>
+#include <memory>
 #include <string>
+
+#include "shm/impl/mapped_file_strategy.h"
+#include "shm/impl/mapped_file_selector.h"
 
 namespace shm {
 
 class MappedFile {
 public:
-    enum class GrowthStrategy {
-        Fixed,
-        Double
-    };
-
     MappedFile();
     ~MappedFile();
 
-    // Create a new file and map it. Existing file will be truncated.
     bool create(const std::string& path, std::size_t size,
                 GrowthStrategy growth = GrowthStrategy::Fixed);
-
-    // Open an existing file and map it. If size is non-zero and the file is
-    // smaller, it will be extended.
     bool open(const std::string& path, std::size_t size = 0,
               GrowthStrategy growth = GrowthStrategy::Fixed);
-
-    // Unmap and close the file.
     void close();
-
-    // Pointer to mapped data.
     void* data();
     const void* data() const;
-
-    // Size of the mapped region.
     std::size_t size() const;
-
-    // Ensure capacity at least new_size using the growth strategy.
     bool ensure_size(std::size_t new_size);
 
 private:
-    GrowthStrategy growth_;
-#ifdef _WIN32
-    void* file_ = nullptr; // HANDLE
-    void* mapping_ = nullptr; // HANDLE
-#else
-    int fd_ = -1;
-#endif
-    void* data_ = nullptr;
-    std::size_t size_ = 0;
-
-    bool map_file(std::size_t size);
-    void unmap_file();
-    bool resize_file(std::size_t new_size);
+    std::unique_ptr<MappedFileStrategy> impl_;
 };
 
 } // namespace shm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,12 @@ add_library(shm STATIC
     mapped_file.cpp
 )
 
+if(WIN32)
+    target_sources(shm PRIVATE windows_mapped_file.cpp)
+else()
+    target_sources(shm PRIVATE posix_mapped_file.cpp)
+endif()
+
 target_include_directories(shm PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/src/mapped_file.cpp
+++ b/src/mapped_file.cpp
@@ -1,158 +1,29 @@
 #include "shm/mapped_file.h"
 
-#include <algorithm>
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
-#include <cstring>
-
 namespace shm {
 
-MappedFile::MappedFile() = default;
+MappedFile::MappedFile() : impl_(std::make_unique<DefaultMappedFileImpl>()) {}
 
-MappedFile::~MappedFile() { close(); }
+MappedFile::~MappedFile() = default;
 
 bool MappedFile::create(const std::string& path, std::size_t size,
                         GrowthStrategy growth) {
-    close();
-    growth_ = growth;
-#ifdef _WIN32
-    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file_ == INVALID_HANDLE_VALUE) return false;
-    mapping_ = nullptr;
-    size_ = size;
-    if (!resize_file(size_)) return false;
-    return true;
-#else
-    fd_ = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
-    if (fd_ < 0) return false;
-    size_ = size;
-    if (!resize_file(size_)) return false;
-    return true;
-#endif
+    return impl_->create(path, size, growth);
 }
 
 bool MappedFile::open(const std::string& path, std::size_t size,
                       GrowthStrategy growth) {
-    close();
-    growth_ = growth;
-#ifdef _WIN32
-    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
-                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (file_ == INVALID_HANDLE_VALUE) return false;
-    mapping_ = nullptr;
-    LARGE_INTEGER fileSize;
-    if (!GetFileSizeEx(reinterpret_cast<HANDLE>(file_), &fileSize)) return false;
-    size_ = static_cast<std::size_t>(fileSize.QuadPart);
-    if (size > size_) {
-        if (!resize_file(size)) return false;
-    } else {
-        if (!map_file(size_)) return false;
-    }
-    return true;
-#else
-    fd_ = ::open(path.c_str(), O_RDWR);
-    if (fd_ < 0) return false;
-    struct stat st;
-    if (fstat(fd_, &st) != 0) return false;
-    size_ = static_cast<std::size_t>(st.st_size);
-    if (size > size_) {
-        if (!resize_file(size)) return false;
-    } else {
-        if (!map_file(size_)) return false;
-    }
-    return true;
-#endif
+    return impl_->open(path, size, growth);
 }
 
-void MappedFile::close() {
-    if (data_) {
-        unmap_file();
-    }
-#ifdef _WIN32
-    if (mapping_) {
-        CloseHandle(reinterpret_cast<HANDLE>(mapping_));
-        mapping_ = nullptr;
-    }
-    if (file_ && file_ != INVALID_HANDLE_VALUE) {
-        CloseHandle(reinterpret_cast<HANDLE>(file_));
-        file_ = nullptr;
-    }
-#else
-    if (fd_ >= 0) {
-        ::close(fd_);
-        fd_ = -1;
-    }
-#endif
-    size_ = 0;
-}
+void MappedFile::close() { impl_->close(); }
 
-void* MappedFile::data() { return data_; }
-const void* MappedFile::data() const { return data_; }
-std::size_t MappedFile::size() const { return size_; }
+void* MappedFile::data() { return impl_->data(); }
+const void* MappedFile::data() const { return impl_->data(); }
+std::size_t MappedFile::size() const { return impl_->size(); }
 
 bool MappedFile::ensure_size(std::size_t new_size) {
-    if (new_size <= size_) return true;
-    std::size_t target = new_size;
-    if (growth_ == GrowthStrategy::Double) {
-        target = std::max(new_size, size_ * 2);
-    }
-    return resize_file(target);
-}
-
-bool MappedFile::map_file(std::size_t map_size) {
-#ifdef _WIN32
-    mapping_ = CreateFileMappingA(reinterpret_cast<HANDLE>(file_), nullptr,
-                                  PAGE_READWRITE, 0, static_cast<DWORD>(map_size),
-                                  nullptr);
-    if (!mapping_) return false;
-    data_ = MapViewOfFile(reinterpret_cast<HANDLE>(mapping_), FILE_MAP_ALL_ACCESS,
-                          0, 0, map_size);
-    if (!data_) return false;
-#else
-    data_ = ::mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
-    if (data_ == MAP_FAILED) {
-        data_ = nullptr;
-        return false;
-    }
-#endif
-    size_ = map_size;
-    return true;
-}
-
-void MappedFile::unmap_file() {
-#ifdef _WIN32
-    if (data_) {
-        UnmapViewOfFile(data_);
-        data_ = nullptr;
-    }
-#else
-    if (data_) {
-        ::munmap(data_, size_);
-        data_ = nullptr;
-    }
-#endif
-}
-
-bool MappedFile::resize_file(std::size_t new_size) {
-    unmap_file();
-#ifdef _WIN32
-    LARGE_INTEGER li;
-    li.QuadPart = static_cast<LONGLONG>(new_size);
-    if (SetFilePointerEx(reinterpret_cast<HANDLE>(file_), li, nullptr, FILE_BEGIN) == 0)
-        return false;
-    if (!SetEndOfFile(reinterpret_cast<HANDLE>(file_))) return false;
-    return map_file(new_size);
-#else
-    if (ftruncate(fd_, new_size) != 0) return false;
-    return map_file(new_size);
-#endif
+    return impl_->ensure_size(new_size);
 }
 
 } // namespace shm

--- a/src/posix_mapped_file.cpp
+++ b/src/posix_mapped_file.cpp
@@ -1,0 +1,84 @@
+#include "shm/impl/mapped_file_posix.h"
+
+namespace shm {
+
+PosixMappedFile::PosixMappedFile() = default;
+PosixMappedFile::~PosixMappedFile() { close(); }
+
+bool PosixMappedFile::create(const std::string& path, std::size_t size,
+                             GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+    fd_ = ::open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (fd_ < 0) return false;
+    size_ = size;
+    if (!resize_file(size_)) return false;
+    return true;
+}
+
+bool PosixMappedFile::open(const std::string& path, std::size_t size,
+                           GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+    fd_ = ::open(path.c_str(), O_RDWR);
+    if (fd_ < 0) return false;
+    struct stat st;
+    if (fstat(fd_, &st) != 0) return false;
+    size_ = static_cast<std::size_t>(st.st_size);
+    if (size > size_) {
+        if (!resize_file(size)) return false;
+    } else {
+        if (!map_file(size_)) return false;
+    }
+    return true;
+}
+
+void PosixMappedFile::close() {
+    if (data_) {
+        unmap_file();
+    }
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
+    size_ = 0;
+}
+
+void* PosixMappedFile::data() { return data_; }
+const void* PosixMappedFile::data() const { return data_; }
+std::size_t PosixMappedFile::size() const { return size_; }
+
+bool PosixMappedFile::ensure_size(std::size_t new_size) {
+    if (new_size <= size_) return true;
+    std::size_t target = new_size;
+    if (growth_ == GrowthStrategy::Double) {
+        target = std::max(new_size, size_ * 2);
+    }
+    return resize_file(target);
+}
+
+bool PosixMappedFile::map_file(std::size_t map_size) {
+    data_ = ::mmap(nullptr, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+    if (data_ == MAP_FAILED) {
+        data_ = nullptr;
+        return false;
+    }
+    size_ = map_size;
+    return true;
+}
+
+void PosixMappedFile::unmap_file() {
+    if (data_) {
+        ::munmap(data_, size_);
+        data_ = nullptr;
+    }
+}
+
+bool PosixMappedFile::resize_file(std::size_t new_size) {
+    unmap_file();
+    if (ftruncate(fd_, new_size) != 0) return false;
+    return map_file(new_size);
+}
+
+} // namespace shm
+

--- a/src/windows_mapped_file.cpp
+++ b/src/windows_mapped_file.cpp
@@ -1,0 +1,98 @@
+#include "shm/impl/mapped_file_windows.h"
+
+namespace shm {
+
+WindowsMappedFile::WindowsMappedFile() = default;
+WindowsMappedFile::~WindowsMappedFile() { close(); }
+
+bool WindowsMappedFile::create(const std::string& path, std::size_t size,
+                               GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE) return false;
+    mapping_ = nullptr;
+    size_ = size;
+    if (!resize_file(size_)) return false;
+    return true;
+}
+
+bool WindowsMappedFile::open(const std::string& path, std::size_t size,
+                             GrowthStrategy growth) {
+    close();
+    growth_ = growth;
+    file_ = CreateFileA(path.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+                        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_ == INVALID_HANDLE_VALUE) return false;
+    mapping_ = nullptr;
+    LARGE_INTEGER fileSize;
+    if (!GetFileSizeEx(reinterpret_cast<HANDLE>(file_), &fileSize)) return false;
+    size_ = static_cast<std::size_t>(fileSize.QuadPart);
+    if (size > size_) {
+        if (!resize_file(size)) return false;
+    } else {
+        if (!map_file(size_)) return false;
+    }
+    return true;
+}
+
+void WindowsMappedFile::close() {
+    if (data_) {
+        unmap_file();
+    }
+    if (mapping_) {
+        CloseHandle(reinterpret_cast<HANDLE>(mapping_));
+        mapping_ = nullptr;
+    }
+    if (file_ && file_ != INVALID_HANDLE_VALUE) {
+        CloseHandle(reinterpret_cast<HANDLE>(file_));
+        file_ = nullptr;
+    }
+    size_ = 0;
+}
+
+void* WindowsMappedFile::data() { return data_; }
+const void* WindowsMappedFile::data() const { return data_; }
+std::size_t WindowsMappedFile::size() const { return size_; }
+
+bool WindowsMappedFile::ensure_size(std::size_t new_size) {
+    if (new_size <= size_) return true;
+    std::size_t target = new_size;
+    if (growth_ == GrowthStrategy::Double) {
+        target = std::max(new_size, size_ * 2);
+    }
+    return resize_file(target);
+}
+
+bool WindowsMappedFile::map_file(std::size_t map_size) {
+    mapping_ = CreateFileMappingA(reinterpret_cast<HANDLE>(file_), nullptr,
+                                  PAGE_READWRITE, 0, static_cast<DWORD>(map_size),
+                                  nullptr);
+    if (!mapping_) return false;
+    data_ = MapViewOfFile(reinterpret_cast<HANDLE>(mapping_), FILE_MAP_ALL_ACCESS,
+                          0, 0, map_size);
+    if (!data_) return false;
+    size_ = map_size;
+    return true;
+}
+
+void WindowsMappedFile::unmap_file() {
+    if (data_) {
+        UnmapViewOfFile(data_);
+        data_ = nullptr;
+    }
+}
+
+bool WindowsMappedFile::resize_file(std::size_t new_size) {
+    unmap_file();
+    LARGE_INTEGER li;
+    li.QuadPart = static_cast<LONGLONG>(new_size);
+    if (SetFilePointerEx(reinterpret_cast<HANDLE>(file_), li, nullptr, FILE_BEGIN) == 0)
+        return false;
+    if (!SetEndOfFile(reinterpret_cast<HANDLE>(file_))) return false;
+    return map_file(new_size);
+}
+
+} // namespace shm
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,10 @@ add_executable(test_mapped_file test_mapped_file.cpp)
 target_link_libraries(test_mapped_file PRIVATE shm)
 add_test(NAME mapped_file_test COMMAND test_mapped_file)
 
+add_executable(test_strategy test_strategy.cpp)
+target_link_libraries(test_strategy PRIVATE shm)
+add_test(NAME strategy_test COMMAND test_strategy)
+
 add_test(
     NAME python_add_test
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/test_python_add.py

--- a/tests/test_strategy.cpp
+++ b/tests/test_strategy.cpp
@@ -1,0 +1,17 @@
+#include <type_traits>
+#include "shm/impl/mapped_file_selector.h"
+#include "shm/impl/mapped_file_posix.h"
+#ifdef _WIN32
+#include "shm/impl/mapped_file_windows.h"
+#endif
+
+int main() {
+#ifdef _WIN32
+    static_assert(std::is_same<shm::DefaultMappedFileImpl, shm::WindowsMappedFile>::value,
+                  "Windows implementation should be selected on Windows");
+#else
+    static_assert(std::is_same<shm::DefaultMappedFileImpl, shm::PosixMappedFile>::value,
+                  "POSIX implementation should be selected on non-Windows");
+#endif
+    return 0;
+}


### PR DESCRIPTION
## Summary
- refactor `MappedFile` to use a strategy implementation
- add POSIX and Windows implementations
- compile the correct impl via a selector header
- add compile-time test for strategy selection
- run CI on Windows and Linux
- fix compilation on MSVC by defining `NOMINMAX`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest --output-on-failure`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685deec0e3b08323b8a88815b17670c2