### PR TITLE
Fix Python path for Windows in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
 
       # 4. Configure your CMake project
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DPython3_EXECUTABLE=${{ env.pythonLocation }}/python
 
       # 5. Build
       - name: Build


### PR DESCRIPTION
## Summary
- ensure the Windows runner uses the setup-python interpreter

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --config Release -j$(nproc)`
- `cd build && ctest --output-on-failure -C Release`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f37a54d348323af4a4c75bc6f5780