### PR TITLE
Fix Windows test failure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,4 +19,8 @@ add_library(shm_py MODULE
     python_module.cpp
 )
 set_target_properties(shm_py PROPERTIES PREFIX "")
+if(WIN32)
+    # Ensure the Python module has the correct extension on Windows
+    set_target_properties(shm_py PROPERTIES SUFFIX ".pyd")
+endif()
 target_link_libraries(shm_py PRIVATE shm Python3::Python)


### PR DESCRIPTION
## Summary
- ensure Python module uses `.pyd` extension on Windows so the module is found during testing

## Testing
- `pytest -q tests/test_python_add.py` *(fails: ModuleNotFoundError: No module named 'shm_py')*

------
https://chatgpt.com/codex/tasks/task_e_685f3a8277688323a8d843639ca982d0