### PR TITLE
Fix Windows test failure

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,4 +19,8 @@ add_library(shm_py MODULE
     python_module.cpp
 )
 set_target_properties(shm_py PROPERTIES PREFIX "")
+if(WIN32)
+    # Ensure the Python module has the correct extension on Windows
+    set_target_properties(shm_py PROPERTIES SUFFIX ".pyd")
+endif()
 target_link_libraries(shm_py PRIVATE shm Python3::Python)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,5 +17,7 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/test_python_add.py
 )
 set_tests_properties(python_add_test PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/src"
+    # Point PYTHONPATH at the directory of the built Python module. This
+    # automatically handles configuration subdirectories on Windows.
+    ENVIRONMENT "PYTHONPATH=$<TARGET_FILE_DIR:shm_py>"
 )


### PR DESCRIPTION
## Summary
- ensure Python module uses `.pyd` extension on Windows so the module is found during testing
- point `PYTHONPATH` at the built module directory using a generator expression

## Testing
- `ctest --output-on-failure -C Release`

------
https://chatgpt.com/codex/tasks/task_e_685f3a8277688323a8d843639ca982d0