### PR TITLE
Add automatic file move with OS locks

### DIFF
--- a/include/shm/mapped_file.h
+++ b/include/shm/mapped_file.h
@@ -27,6 +27,12 @@ public:
 
 private:
     std::unique_ptr<MappedFileStrategy> impl_;
+    std::string path_;
+    int lock_fd_ = -1;
+    static constexpr std::size_t kMoveThreshold = 1024;
+
+    void register_reader();
+    void decrement_reader(std::size_t last_size);
 };
 
 } // namespace shm

--- a/src/mapped_file.cpp
+++ b/src/mapped_file.cpp
@@ -1,22 +1,52 @@
 #include "shm/mapped_file.h"
+#include <filesystem>
+#include <cstdio>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
 
 namespace shm {
 
 MappedFile::MappedFile() : impl_(std::make_unique<DefaultMappedFileImpl>()) {}
 
-MappedFile::~MappedFile() = default;
+MappedFile::~MappedFile() { close(); }
 
 bool MappedFile::create(const std::string& path, std::size_t size,
                         GrowthStrategy growth) {
-    return impl_->create(path, size, growth);
+    if (!impl_->create(path, size, growth)) {
+        return false;
+    }
+    path_ = path;
+    register_reader();
+    return true;
 }
 
 bool MappedFile::open(const std::string& path, std::size_t size,
                       GrowthStrategy growth) {
-    return impl_->open(path, size, growth);
+    if (!impl_->open(path, size, growth)) {
+        return false;
+    }
+    path_ = path;
+    register_reader();
+    return true;
 }
 
-void MappedFile::close() { impl_->close(); }
+void MappedFile::close() {
+    std::size_t sz = impl_->size();
+    impl_->close();
+    decrement_reader(sz);
+}
+
+void MappedFile::register_reader() {
+    std::string lock_path = path_ + ".lock";
+    lock_fd_ = ::open(lock_path.c_str(), O_RDWR | O_CREAT, 0666);
+    if (lock_fd_ >= 0) {
+        flock(lock_fd_, LOCK_SH);
+    }
+}
 
 void* MappedFile::data() { return impl_->data(); }
 const void* MappedFile::data() const { return impl_->data(); }
@@ -24,6 +54,29 @@ std::size_t MappedFile::size() const { return impl_->size(); }
 
 bool MappedFile::ensure_size(std::size_t new_size) {
     return impl_->ensure_size(new_size);
+}
+
+void MappedFile::decrement_reader(std::size_t last_size) {
+    if (path_.empty() || lock_fd_ < 0) {
+        path_.clear();
+        return;
+    }
+
+    std::string lock_path = path_ + ".lock";
+
+    flock(lock_fd_, LOCK_UN);
+    if (flock(lock_fd_, LOCK_EX | LOCK_NB) == 0) {
+        if (last_size >= kMoveThreshold) {
+            std::string new_path = path_ + ".moved";
+            std::rename(path_.c_str(), new_path.c_str());
+        }
+        ::unlink(lock_path.c_str());
+        flock(lock_fd_, LOCK_UN);
+    }
+
+    ::close(lock_fd_);
+    lock_fd_ = -1;
+    path_.clear();
 }
 
 } // namespace shm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,14 @@ add_executable(test_mapped_file test_mapped_file.cpp)
 target_link_libraries(test_mapped_file PRIVATE shm)
 add_test(NAME mapped_file_test COMMAND test_mapped_file)
 
+add_executable(test_auto_move test_auto_move.cpp)
+target_link_libraries(test_auto_move PRIVATE shm)
+add_test(NAME auto_move_test COMMAND test_auto_move)
+
+add_executable(test_no_move_small test_no_move_small.cpp)
+target_link_libraries(test_no_move_small PRIVATE shm)
+add_test(NAME no_move_small_test COMMAND test_no_move_small)
+
 add_executable(test_strategy test_strategy.cpp)
 target_link_libraries(test_strategy PRIVATE shm)
 add_test(NAME strategy_test COMMAND test_strategy)

--- a/tests/test_auto_move.cpp
+++ b/tests/test_auto_move.cpp
@@ -1,0 +1,44 @@
+#include <cassert>
+#include <fstream>
+#include <cstdio>
+#include "shm/mapped_file.h"
+
+int main() {
+    const char* path = "test_auto.bin";
+    const char* moved = "test_auto.bin.moved";
+
+    // Ensure clean slate
+    std::remove(path);
+    std::remove(moved);
+
+    // Writer creates the file
+    shm::MappedFile writer;
+    assert(writer.create(path, 1024));
+    char* wptr = static_cast<char*>(writer.data());
+    assert(wptr);
+    wptr[0] = 'Z';
+
+    // Second reader opens the same file
+    shm::MappedFile reader;
+    assert(reader.open(path));
+    const char* rptr = static_cast<const char*>(reader.data());
+    assert(rptr && rptr[0] == 'Z');
+
+    // Close writer - file should still exist
+    writer.close();
+    std::ifstream check(path);
+    assert(check.good());
+    check.close();
+
+    // Close final reader - file should be moved
+    reader.close();
+    assert(!std::ifstream(path).good());
+    std::ifstream moved_in(moved);
+    char c = 0;
+    moved_in.read(&c, 1);
+    assert(c == 'Z');
+    moved_in.close();
+
+    std::remove(moved);
+    return 0;
+}

--- a/tests/test_mapped_file.cpp
+++ b/tests/test_mapped_file.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 #include <fstream>
+#include <string>
 #include "shm/mapped_file.h"
 
 int main() {
@@ -15,11 +16,12 @@ int main() {
     ptr[0] = 'A';
     mf.close();
 
-    std::ifstream in(path, std::ios::binary);
+    std::string moved_path = std::string(path) + ".moved";
+    std::ifstream in(moved_path, std::ios::binary);
     char c = 0;
     in.read(&c, 1);
     assert(c == 'A');
     in.close();
-    std::remove(path);
+    std::remove(moved_path.c_str());
     return 0;
 }

--- a/tests/test_no_move_small.cpp
+++ b/tests/test_no_move_small.cpp
@@ -1,0 +1,27 @@
+#include <cassert>
+#include <fstream>
+#include <cstdio>
+#include "shm/mapped_file.h"
+
+int main() {
+    const char* path = "test_small.bin";
+    const char* moved = "test_small.bin.moved";
+
+    std::remove(path);
+    std::remove(moved);
+
+    shm::MappedFile mf;
+    assert(mf.create(path, 512));
+
+    char* ptr = static_cast<char*>(mf.data());
+    assert(ptr);
+    ptr[0] = 'X';
+    mf.close();
+
+    // File is below threshold so it should not be moved
+    assert(std::ifstream(path).good());
+    assert(!std::ifstream(moved).good());
+
+    std::remove(path);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- track readers using a `.lock` file and `flock`
- move the backing file once last reader releases the lock

## Testing
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `cd build && ctest -V`


------
https://chatgpt.com/codex/tasks/task_e_6861aae6367083239c3b5502199a8d74